### PR TITLE
fix: add missing 'dev' script in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "dev":"react-scripts start"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
# Related Issue
Issue on running (npm run dev) , no dev scripts in package.json

Fixes:  1
# Description

This pull request addresses the missing "dev" script in the package.json file, which was preventing the development server from running. By adding this script, developers can now easily start the development environment using npm run dev. This change enhances the development workflow and ensures consistency across the team. No additional dependencies are required for this change.

# Type of PR

- [ ✅] Bug fix


# Checklist:

- [✅ ] I have made this change from my own.
- [ ] I have taken help from some online resources.
- [ ✅] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ✅] My changes generate no new warnings.
- [ ✅] I have tested the changes thoroughly before submitting this pull request.Description


